### PR TITLE
[refactor/#35] 엔드포인트 수정

### DIFF
--- a/apps/authentication/urls.py
+++ b/apps/authentication/urls.py
@@ -1,6 +1,3 @@
 from django.urls import path
-from .views import GoogleLoginView
 
-urlpatterns = [
-    path('google', GoogleLoginView.as_view()),
-]
+urlpatterns = []

--- a/apps/authentication/views.py
+++ b/apps/authentication/views.py
@@ -12,7 +12,12 @@ from datetime import datetime, timedelta
 GOOGLE_TOKEN_INFO_URL = "https://oauth2.googleapis.com/tokeninfo"
 
 class GoogleLoginView(APIView):
-    @swagger_auto_schema(request_body=GoogleLoginSerializer)
+    @swagger_auto_schema(
+        tags=["oauth"],
+        operation_summary="Google OAuth 로그인",
+        operation_description="Google ID Token을 사용한 OAuth 로그인 및 JWT 토큰 발급",
+        request_body=GoogleLoginSerializer
+    )
     def post(self, request):
         serializer = GoogleLoginSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/apps/avatars/views.py
+++ b/apps/avatars/views.py
@@ -120,6 +120,8 @@ class AvatarListView(APIView):
     parser_classes = [MultiPartParser]  # 파일 업로드를 위한 파서 추가
     
     @swagger_auto_schema(
+        tags=["avatars"],
+        operation_summary="아바타 목록 조회",
         operation_description="VisionStory에서 사용 가능한 아바타 목록을 조회합니다",
         responses={
             200: openapi.Response(
@@ -192,6 +194,8 @@ class AvatarListView(APIView):
             )
 
     @swagger_auto_schema(
+        tags=["avatars"],
+        operation_summary="아바타 생성",
         operation_description="이미지를 업로드하면 아바타를 생성합니다. 실패 시 다른 이미지 업로드를 요청합니다.",
         manual_parameters=[
             openapi.Parameter(

--- a/apps/place/views.py
+++ b/apps/place/views.py
@@ -16,10 +16,11 @@ MAX_RESULTS = 4
 class NearbyMuseumView(APIView):
 
     @swagger_auto_schema(
-        request_body=NearbyMuseumRequestSerializer,
-        responses={200: NearbyMuseumResponseSerializer(many=True)},
+        tags=["places"],
         operation_summary="근처 박물관 검색",
-        operation_description="사용자의 위도, 경도, 반경을 기반으로 Google Maps MCP를 사용해 근처 박물관을 검색합니다."
+        operation_description="사용자의 위도, 경도, 반경을 기반으로 Google Maps MCP를 사용해 근처 박물관을 검색합니다.",
+        request_body=NearbyMuseumRequestSerializer,
+        responses={200: NearbyMuseumResponseSerializer(many=True)}
     )
     def post(self, request, *args, **kwargs):
         serializer = NearbyMuseumRequestSerializer(data=request.data)

--- a/apps/videos/urls.py
+++ b/apps/videos/urls.py
@@ -4,7 +4,7 @@ from .views.video_crud_views import VideoUploadView
 from .views.visionstory_latest_view import VisionStoryLatestVideoView
 
 urlpatterns = [
-    path('/generate', VideoCreationView.as_view(), name='video_generation'),
-    path('/visionstory', VisionStoryLatestVideoView.as_view(), name='visionstory_latest'),
+    path('generate', VideoCreationView.as_view(), name='video_generation'),
+    path('visionstory', VisionStoryLatestVideoView.as_view(), name='visionstory_latest'),
     path('', VideoUploadView.as_view(), name='video-upload'),
 ]

--- a/apps/videos/urls.py
+++ b/apps/videos/urls.py
@@ -4,7 +4,7 @@ from .views.video_crud_views import VideoUploadView
 from .views.visionstory_latest_view import VisionStoryLatestVideoView
 
 urlpatterns = [
-    path('generate', VideoCreationView.as_view(), name='video_generation'),
-    path('visionstory', VisionStoryLatestVideoView.as_view(), name='visionstory_latest'),
-    path('', VideoUploadView.as_view(), name='video-upload'),
+    path('videos/generate', VideoCreationView.as_view(), name='video_generation'),
+    path('videos/visionstory', VisionStoryLatestVideoView.as_view(), name='visionstory_latest'),
+    path('videos', VideoUploadView.as_view(), name='video-upload'),
 ]

--- a/apps/videos/views/video_creation_view.py
+++ b/apps/videos/views/video_creation_view.py
@@ -27,6 +27,8 @@ class VideoCreationView(APIView):
         self.video_generator = VideoGenerator()
     
     @swagger_auto_schema(
+        tags=["videos"],
+        operation_summary="작품 기반 영상 생성",
         operation_description="OCR 텍스트를 기반으로 작품 정보를 추출하고 영상을 자동 생성합니다",
         request_body=openapi.Schema(
             type=openapi.TYPE_OBJECT,

--- a/apps/videos/views/video_crud_views.py
+++ b/apps/videos/views/video_crud_views.py
@@ -15,6 +15,8 @@ class VideoUploadView(APIView):
     permission_classes = [AllowAny]
     
     @swagger_auto_schema(
+        tags=["videos"],
+        operation_summary="영상 저장",
         operation_description="영상을 자동으로 저장합니다",
         request_body=openapi.Schema(
             type=openapi.TYPE_OBJECT,

--- a/apps/videos/views/visionstory_latest_view.py
+++ b/apps/videos/views/visionstory_latest_view.py
@@ -2,6 +2,8 @@ import logging
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
 from apps.videos.services.visionstory_service import VisionStoryService
 
 logger = logging.getLogger(__name__)
@@ -10,6 +12,34 @@ logger = logging.getLogger(__name__)
 class VisionStoryLatestVideoView(APIView):
     """VisionStory에서 생성된 가장 최근 영상 URL을 조회하는 API"""
     
+    @swagger_auto_schema(
+        tags=["videos"],
+        operation_summary="최근 영상 조회",
+        operation_description="VisionStory에서 생성된 가장 최근 영상의 URL과 정보를 조회합니다",
+        responses={
+            200: openapi.Response(
+                description="최근 영상 조회 성공",
+                schema=openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    properties={
+                        'success': openapi.Schema(type=openapi.TYPE_BOOLEAN, example=True),
+                        'data': openapi.Schema(
+                            type=openapi.TYPE_OBJECT,
+                            properties={
+                                'video_id': openapi.Schema(type=openapi.TYPE_STRING, description='영상 ID'),
+                                'video_url': openapi.Schema(type=openapi.TYPE_STRING, description='영상 URL'),
+                                'status': openapi.Schema(type=openapi.TYPE_STRING, description='영상 상태'),
+                                'created_at': openapi.Schema(type=openapi.TYPE_STRING, description='생성 시간'),
+                                'duration': openapi.Schema(type=openapi.TYPE_INTEGER, description='영상 길이(초)'),
+                            }
+                        ),
+                    }
+                )
+            ),
+            404: openapi.Response(description="생성된 영상이 없음"),
+            500: openapi.Response(description="서버 오류")
+        }
+    )
     def get(self, request):
         """
         VisionStory에서 생성된 가장 최근 영상의 URL을 반환합니다.

--- a/config/urls.py
+++ b/config/urls.py
@@ -8,16 +8,16 @@ from drf_yasg import openapi
 # Video views are now imported through apps.videos.urls
 from apps.authentication.views import GoogleLoginView
 
-# 전체 경로를 위한 URL 패턴들 - 모든 API는 /api/v1으로 시작
+# 전체 경로를 위한 URL 패턴들 - 모든 API는 /api/v1으로 시작하고 도메인별로 분류됨
 api_urls = [
     # OAuth 관련
-    path('oauth/google', GoogleLoginView.as_view(), name='oauth_google'),
+    path('api/v1/oauth/google', GoogleLoginView.as_view(), name='oauth_google'),
     
     # Avatars 관련
-    path('avatars', include('apps.avatars.urls')),
+    path('api/v1/avatars', include('apps.avatars.urls')),
     
     # Videos 관련  
-    path('', include('apps.videos.urls')),
+    path('api/v1/videos/', include('apps.videos.urls')),
     
     # Places 관련
     path('api/v1/places/', include('apps.place.urls')),
@@ -35,15 +35,15 @@ schema_view = get_schema_view(
     ),
     public=True,
     permission_classes=[AllowAny],
-    patterns=[  # 실제 API만 포함 - 모든 API는 /api/v1으로 시작
+    patterns=[  # 실제 API만 포함 - /api/v1 prefix + 도메인별 태그 분류
         # OAuth
-        path('oauth/google', GoogleLoginView.as_view()),
+        path('api/v1/oauth/google', GoogleLoginView.as_view()),
         
         # Avatars  
-        path('avatars', include('apps.avatars.urls')),
+        path('api/v1/avatars', include('apps.avatars.urls')),
         
         # Videos
-        path('videos/', include('apps.videos.urls')),
+        path('api/v1/videos/', include('apps.videos.urls')),
         
         # Places
         path('api/v1/places/', include('apps.place.urls')),
@@ -58,7 +58,7 @@ urlpatterns = [
     path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
     path('', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
-    # 기존 api/auth/ 경로는 제거됨 - 모든 인증은 /api/v1/oauth/로 통합
+    # 모든 API가 /api/v1/ prefix로 통합됨 - Swagger는 도메인별 태그로 분류
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/config/urls.py
+++ b/config/urls.py
@@ -17,7 +17,7 @@ api_urls = [
     path('avatars', include('apps.avatars.urls')),
     
     # Videos 관련  
-    path('videos', include('apps.videos.urls')),
+    path('', include('apps.videos.urls')),
     
     # Places 관련
     path('api/v1/places/', include('apps.place.urls')),
@@ -37,13 +37,13 @@ schema_view = get_schema_view(
     permission_classes=[AllowAny],
     patterns=[  # 실제 API만 포함 - 모든 API는 /api/v1으로 시작
         # OAuth
-        path('api/v1/oauth/google/', GoogleLoginView.as_view()),
+        path('oauth/google', GoogleLoginView.as_view()),
         
         # Avatars  
-        path('api/v1/avatars/', include('apps.avatars.urls')),
+        path('avatars', include('apps.avatars.urls')),
         
         # Videos
-        path('api/v1/videos/', include('apps.videos.urls')),
+        path('videos/', include('apps.videos.urls')),
         
         # Places
         path('api/v1/places/', include('apps.place.urls')),

--- a/config/urls.py
+++ b/config/urls.py
@@ -17,7 +17,7 @@ api_urls = [
     path('api/v1/avatars', include('apps.avatars.urls')),
     
     # Videos 관련  
-    path('api/v1/videos/', include('apps.videos.urls')),
+    path('api/v1/', include('apps.videos.urls')),
     
     # Places 관련
     path('api/v1/places/', include('apps.place.urls')),
@@ -43,7 +43,7 @@ schema_view = get_schema_view(
         path('api/v1/avatars', include('apps.avatars.urls')),
         
         # Videos
-        path('api/v1/videos/', include('apps.videos.urls')),
+        path('api/v1/', include('apps.videos.urls')),
         
         # Places
         path('api/v1/places/', include('apps.place.urls')),

--- a/config/urls.py
+++ b/config/urls.py
@@ -5,18 +5,22 @@ from django.conf.urls.static import static
 from rest_framework.permissions import AllowAny
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
-from apps.videos.views.video_creation_view import VideoCreationView
-from apps.videos.views.video_crud_views import VideoUploadView
-from apps.videos.views.visionstory_latest_view import VisionStoryLatestVideoView
+# Video views are now imported through apps.videos.urls
 from apps.authentication.views import GoogleLoginView
 
-# 전체 경로를 위한 URL 패턴들 - 공통 경로 제거
+# 전체 경로를 위한 URL 패턴들 - 모든 API는 /api/v1으로 시작
 api_urls = [
-    path('api/v1/videos/generate', VideoCreationView.as_view(), name='video_generation'),
-    path('api/v1/videos/visionstory', VisionStoryLatestVideoView.as_view(), name='visionstory_latest'),
-    path('api/v1/videos', VideoUploadView.as_view(), name='video-upload'),
-    path('api/v1/avatars', include('apps.avatars.urls')),
-    path('places/', include('apps.place.urls')),
+    # OAuth 관련
+    path('oauth/google', GoogleLoginView.as_view(), name='oauth_google'),
+    
+    # Avatars 관련
+    path('avatars', include('apps.avatars.urls')),
+    
+    # Videos 관련  
+    path('videos', include('apps.videos.urls')),
+    
+    # Places 관련
+    path('api/v1/places/', include('apps.place.urls')),
 ]
 
 # Swagger 설정 - 전체 경로 표시용
@@ -31,26 +35,30 @@ schema_view = get_schema_view(
     ),
     public=True,
     permission_classes=[AllowAny],
-    patterns=[  # 실제 API만 포함
-        path('api/v1/videos', include('apps.videos.urls')),
-        path('api/v1/avatars', include('apps.avatars.urls')),
-        path('places/', include('apps.place.urls')),
-        path('users/google/', GoogleLoginView.as_view()),  # 구글 OAuth 엔드포인트 Swagger에 포함
-        path('', include('apps.authentication.urls')),
+    patterns=[  # 실제 API만 포함 - 모든 API는 /api/v1으로 시작
+        # OAuth
+        path('api/v1/oauth/google/', GoogleLoginView.as_view()),
+        
+        # Avatars  
+        path('api/v1/avatars/', include('apps.avatars.urls')),
+        
+        # Videos
+        path('api/v1/videos/', include('apps.videos.urls')),
+        
+        # Places
+        path('api/v1/places/', include('apps.place.urls')),
     ],
 )
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('places/', include('apps.place.urls')),
-    path('users/google/', GoogleLoginView.as_view()),  # 구글 OAuth 엔드포인트 직접 연결
 ] + api_urls + [
     # Swagger API 문서
     re_path(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
     path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
     path('', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
-    path('api/auth/', include('apps.authentication.urls')),
+    # 기존 api/auth/ 경로는 제거됨 - 모든 인증은 /api/v1/oauth/로 통합
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * 아바타, 영상 생성, 영상 업로드, VisionStory 최신 영상 조회, Google OAuth 로그인 등 주요 API 엔드포인트에 Swagger 문서 태그와 요약 정보가 추가되어 API 문서가 개선되었습니다.

* **리팩터**
  * 모든 API 엔드포인트가 `/api/v1/`로 통합되어 도메인별로 정리되었습니다.
  * 영상 관련 API 경로가 `videos` 접두어로 일관성 있게 변경되었습니다.
  * Google 로그인 관련 엔드포인트가 인증 URL에서 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->