### PR TITLE
[setting/#39] https 도메인 추가

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -45,7 +45,7 @@ services:
       python manage.py runserver 0.0.0.0:8000"
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.backend.rule=Host(`api.hiedu.site`)"
+      - "traefik.http.routers.backend.rule=Host(`api.hiedu.site`) || Host(`hiedu.site`)"
       - "traefik.http.routers.backend.entrypoints=websecure"
       - "traefik.http.routers.backend.tls.certresolver=letsencrypt"
       - "traefik.http.services.backend.loadbalancer.server.port=8000"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 백엔드 서비스가 이제 `api.hiedu.site` 뿐만 아니라 `hiedu.site` 도메인으로 요청을 받을 수 있도록 Traefik 라우팅 규칙이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->