### PR TITLE
[setting/#39] https 라우팅

### DIFF
--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -51,3 +51,12 @@ CORS_ORIGIN_ALLOW_ALL = False
 # HTTPS 보안 설정 (Traefik 뒤에서 실행될 때)
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 SECURE_SSL_REDIRECT = False  # Traefik에서 리다이렉트 처리
+
+# 추가 HTTPS 보안 설정
+SECURE_HSTS_SECONDS = 31536000  # 1년 (HSTS: HTTP Strict Transport Security)
+SECURE_HSTS_INCLUDE_SUBDOMAINS = True  # 서브도메인에도 HSTS 적용
+SECURE_HSTS_PRELOAD = True  # HSTS preload 리스트 포함 가능
+SECURE_CONTENT_TYPE_NOSNIFF = True  # MIME 타입 스니핑 방지
+SECURE_BROWSER_XSS_FILTER = True  # XSS 필터 활성화
+SESSION_COOKIE_SECURE = True  # 세션 쿠키 HTTPS 전용
+CSRF_COOKIE_SECURE = True  # CSRF 쿠키 HTTPS 전용

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -47,3 +47,7 @@ else:
     }
 
 CORS_ORIGIN_ALLOW_ALL = False
+
+# HTTPS 보안 설정 (Traefik 뒤에서 실행될 때)
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SECURE_SSL_REDIRECT = False  # Traefik에서 리다이렉트 처리

--- a/config/urls.py
+++ b/config/urls.py
@@ -35,7 +35,7 @@ schema_view = get_schema_view(
     ),
     public=True,
     permission_classes=[AllowAny],
-    schemes=['https'],  # Swagger UI에서 HTTPS만 사용하도록 강제
+    schemes=['https'] if not settings.DEBUG else ['http', 'https'],  # DEBUG 환경에 따라 분기 처리
     patterns=[  # 실제 API만 포함 - /api/v1 prefix + 도메인별 태그 분류
         # OAuth
         path('api/v1/oauth/google', GoogleLoginView.as_view()),

--- a/config/urls.py
+++ b/config/urls.py
@@ -35,6 +35,7 @@ schema_view = get_schema_view(
     ),
     public=True,
     permission_classes=[AllowAny],
+    schemes=['https'],  # Swagger UI에서 HTTPS만 사용하도록 강제
     patterns=[  # 실제 API만 포함 - /api/v1 prefix + 도메인별 태그 분류
         # OAuth
         path('api/v1/oauth/google', GoogleLoginView.as_view()),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Swagger API 문서가 이제 HTTPS로만 제공됩니다.

* **버그 수정**
  * 프록시(예: Traefik) 환경에서 HTTPS 요청이 올바르게 감지되도록 보안 설정이 추가되었습니다.
  * SSL 리디렉션이 외부에서 처리될 수 있도록 설정이 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->