### PR TITLE
[setting/#39] https

### DIFF
--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -51,3 +51,12 @@ CORS_ORIGIN_ALLOW_ALL = False
 # HTTPS 보안 설정 (Traefik 뒤에서 실행될 때)
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 SECURE_SSL_REDIRECT = False  # Traefik에서 리다이렉트 처리
+
+# 추가 HTTPS 보안 설정
+SECURE_HSTS_SECONDS = 31536000  # 1년 (HSTS: HTTP Strict Transport Security)
+SECURE_HSTS_INCLUDE_SUBDOMAINS = True  # 서브도메인에도 HSTS 적용
+SECURE_HSTS_PRELOAD = True  # HSTS preload 리스트 포함 가능
+SECURE_CONTENT_TYPE_NOSNIFF = True  # MIME 타입 스니핑 방지
+SECURE_BROWSER_XSS_FILTER = True  # XSS 필터 활성화
+SESSION_COOKIE_SECURE = True  # 세션 쿠키 HTTPS 전용
+CSRF_COOKIE_SECURE = True  # CSRF 쿠키 HTTPS 전용

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -47,3 +47,7 @@ else:
     }
 
 CORS_ORIGIN_ALLOW_ALL = False
+
+# HTTPS 보안 설정 (Traefik 뒤에서 실행될 때)
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SECURE_SSL_REDIRECT = False  # Traefik에서 리다이렉트 처리

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -47,16 +47,3 @@ else:
     }
 
 CORS_ORIGIN_ALLOW_ALL = False
-
-# HTTPS 보안 설정 (Traefik 뒤에서 실행될 때)
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
-SECURE_SSL_REDIRECT = False  # Traefik에서 리다이렉트 처리
-
-# 추가 HTTPS 보안 설정
-SECURE_HSTS_SECONDS = 31536000  # 1년 (HSTS: HTTP Strict Transport Security)
-SECURE_HSTS_INCLUDE_SUBDOMAINS = True  # 서브도메인에도 HSTS 적용
-SECURE_HSTS_PRELOAD = True  # HSTS preload 리스트 포함 가능
-SECURE_CONTENT_TYPE_NOSNIFF = True  # MIME 타입 스니핑 방지
-SECURE_BROWSER_XSS_FILTER = True  # XSS 필터 활성화
-SESSION_COOKIE_SECURE = True  # 세션 쿠키 HTTPS 전용
-CSRF_COOKIE_SECURE = True  # CSRF 쿠키 HTTPS 전용

--- a/config/urls.py
+++ b/config/urls.py
@@ -2,11 +2,25 @@ from django.contrib import admin
 from django.urls import path, include, re_path
 from django.conf import settings
 from django.conf.urls.static import static
+from django.http import JsonResponse
 from rest_framework.permissions import AllowAny
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 # Video views are now imported through apps.videos.urls
 from apps.authentication.views import GoogleLoginView
+
+# 루트 경로 처리 - API 서버 상태 확인
+def root_api_view(request):
+    return JsonResponse({
+        'message': 'TeamA API Server is running! 🚀',
+        'status': 'healthy',
+        'version': 'v1',
+        'endpoints': {
+            'api_docs': '/swagger/',
+            'admin': '/admin/',
+            'api_base': '/api/v1/'
+        }
+    })
 
 # 전체 경로를 위한 URL 패턴들 - 모든 API는 /api/v1으로 시작하고 도메인별로 분류됨
 api_urls = [
@@ -53,12 +67,12 @@ schema_view = get_schema_view(
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('', root_api_view, name='api-root'),  # 루트 경로 - API 상태 확인
 ] + api_urls + [
     # Swagger API 문서
     re_path(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
     path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
-    path('', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     # 모든 API가 /api/v1/ prefix로 통합됨 - Swagger는 도메인별 태그로 분류
 ]
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -35,7 +35,7 @@ schema_view = get_schema_view(
     ),
     public=True,
     permission_classes=[AllowAny],
-    schemes=['https'],  # Swagger UI에서 HTTPS만 사용하도록 강제
+    schemes=['https'] if not settings.DEBUG else ['http', 'https'],  # DEBUG 환경에 따라 분기 처리
     patterns=[  # 실제 API만 포함 - /api/v1 prefix + 도메인별 태그 분류
         # OAuth
         path('api/v1/oauth/google', GoogleLoginView.as_view()),

--- a/config/urls.py
+++ b/config/urls.py
@@ -49,7 +49,7 @@ schema_view = get_schema_view(
     ),
     public=True,
     permission_classes=[AllowAny],
-    schemes=['https'] if not settings.DEBUG else ['http', 'https'],  # DEBUG 환경에 따라 분기 처리
+    url='https://hiedu.site/' if not settings.DEBUG else None,  # 프로덕션에서 HTTPS URL 명시
     patterns=[  # 실제 API만 포함 - /api/v1 prefix + 도메인별 태그 분류
         # OAuth
         path('api/v1/oauth/google', GoogleLoginView.as_view()),

--- a/config/urls.py
+++ b/config/urls.py
@@ -35,6 +35,7 @@ schema_view = get_schema_view(
     ),
     public=True,
     permission_classes=[AllowAny],
+    schemes=['https'],  # Swagger UI에서 HTTPS만 사용하도록 강제
     patterns=[  # 실제 API만 포함 - /api/v1 prefix + 도메인별 태그 분류
         # OAuth
         path('api/v1/oauth/google', GoogleLoginView.as_view()),

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -45,7 +45,7 @@ services:
       python manage.py runserver 0.0.0.0:8000"
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.backend.rule=Host(`api.hiedu.site`)"
+      - "traefik.http.routers.backend.rule=Host(`api.hiedu.site`) || Host(`hiedu.site`)"
       - "traefik.http.routers.backend.entrypoints=websecure"
       - "traefik.http.routers.backend.tls.certresolver=letsencrypt"
       - "traefik.http.services.backend.loadbalancer.server.port=8000"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 루트 URL(‘/’)에서 API 서버 상태, 버전, 주요 엔드포인트 정보를 제공하는 상태 확인 JSON 응답을 추가했습니다.

* **버그 수정**
  * Swagger UI가 루트 경로에서 제거되고, 루트 경로가 상태 확인 엔드포인트로 변경되었습니다.

* **기타**
  * 백엔드 서비스가 `api.hiedu.site`와 `hiedu.site` 도메인 모두에서 접근 가능하도록 라우팅 규칙이 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->